### PR TITLE
Handle "GetBinaryState" requests and cache device states

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ let fauxMo = new FauxMo(
           console.log('office fan action:', action);
         },
         getStateHandler: (device) => {
-          // Return 1 (on), off (0), or undefined to return 
-          // the last known device state.
+          // For "on" return: true / 1 / 'on'
+          // For "off" return: false / 0 / 'off'
+          // For the last known state of the device, return nothing or undefined.
           return 1; // Always on.
         }
       }
@@ -69,4 +70,4 @@ The device object needs the following properties:
 
 `handler` - a function that will be called when the echo is attempting to perform the action.  This function takes an 'action' parameter which, when called, will be `on` or `off`.
 
-`getStateHandler` - an optional function that will be called when the echo is asking for the state of the device.  This function takes an 'device' parameter which will contain the `device.id`, `device.name` and `device.port` of the queried device.  The return value is expected to be `1` if the device is on, `0` if it's off, or `undefined` if the last remembered state should be used.
+`getStateHandler` - an optional function that will be called when the echo is asking for the state of the device. This function takes an 'device' parameter which will contain the `device.id`, `device.name` and `device.port` of the queried device. The return value is expected to be `true`, `1` or `'on'` if the device is on, `false`, `0` or `'off'` if it's off, or `undefined` if the last known device state should be used.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ let fauxMo = new FauxMo(
         port: 11001,
         handler: (action) => {
           console.log('office fan action:', action);
+        },
+        getStateHandler: (device) => {
+          // Return 1 (on), off (0), or undefined to return 
+          // the last known device state.
+          return 1; // Always on.
         }
       }
     ]
@@ -63,3 +68,5 @@ The device object needs the following properties:
 `port` - each fake device needs to have a unique port.  The amazon echo does not send back the device id in the action requests so the device is determined by the port number.  FauxMo listens for actions on each device port.
 
 `handler` - a function that will be called when the echo is attempting to perform the action.  This function takes an 'action' parameter which, when called, will be `on` or `off`.
+
+`getStateHandler` - an optional function that will be called when the echo is asking for the state of the device.  This function takes an 'device' parameter which will contain the `device.id`, `device.name` and `device.port` of the queried device.  The return value is expected to be `1` if the device is on, `0` if it's off, or `undefined` if the last remembered state should be used.

--- a/lib/deviceEndpoints.js
+++ b/lib/deviceEndpoints.js
@@ -77,8 +77,8 @@ module.exports.startVirtualDeviceEndpoints = function(state, getDeviceSetupFunct
                 port: device.port, id: device.id });
               //handler can return undefined to force usage of the cached state
               if (newState !== undefined) {
-                //accept a string ('on', 'off') or integer (0, 1) as result
-                state = newState === 1 || newState === 'on' ? 1 : 0;
+                //accept a boolean (true, false), string ('on', 'off') or integer (1, 0) as result
+                state = newState === true || newState === 1 || newState === 'on' ? 1 : 0;
               }
             }
 

--- a/lib/deviceEndpoints.js
+++ b/lib/deviceEndpoints.js
@@ -5,6 +5,7 @@ const Boom = require('boom');
 const debug = require('debug')('deviceEndpoints');
 const Hapi = require('hapi');
 const q = require('q');
+const xmlResponse = require('./xml-response');
 
 let hapiServer;
 
@@ -31,6 +32,7 @@ module.exports.startVirtualDeviceEndpoints = function(state, getDeviceSetupFunct
   return stopServer()
     .then(() => {
       hapiServer = new Hapi.Server();
+      let lastKnownDeviceStates = new Map();
 
       _.forOwn(state.devices, (device, id) => {
         hapiServer.connection({ port: device.port, labels: [id] });
@@ -67,10 +69,28 @@ module.exports.startVirtualDeviceEndpoints = function(state, getDeviceSetupFunct
             return Boom.badRequest();
           }
 
+          if (request.payload.indexOf('</u:GetBinaryState>') !== -1) {
+            let state = lastKnownDeviceStates.get(device.id) || 0;
+            if (_.isFunction(device.getStateHandler)) {
+              let newState = device.getStateHandler({ name: device.name, 
+                port: device.port, id: device.id });
+              //handler can return undefined to force usage of the cached state
+              if (newState !== undefined) {
+                //accept a string ('on', 'off') or integer (0, 1) as result
+                state = newState === 1 || newState === 'on' ? 1 : 0;
+              }
+            }
+
+            debug('?? State requested for device:', device.name, '- state:', state);
+            return reply(xmlResponse({ getOrSet: 'get', state }));
+          }
+
           if (request.payload.indexOf('<BinaryState>1</BinaryState>') > 0) {
             action = 'on';
+            lastKnownDeviceStates.set(device.id, 1);
           } else if (request.payload.indexOf('<BinaryState>0</BinaryState>') > 0) {
             action = 'off';
+            lastKnownDeviceStates.set(device.id, 0);
           }
 
           debug('!! Action received for device:\n', device, '\naction:\n', action);
@@ -81,7 +101,7 @@ module.exports.startVirtualDeviceEndpoints = function(state, getDeviceSetupFunct
             debug('Warning, device has no handler:', device);
           }
 
-          reply({ok: true});
+          reply(xmlResponse({ getOrSet: 'set', state }))
         }
       });
 

--- a/lib/deviceEndpoints.js
+++ b/lib/deviceEndpoints.js
@@ -32,7 +32,7 @@ module.exports.startVirtualDeviceEndpoints = function(state, getDeviceSetupFunct
   return stopServer()
     .then(() => {
       hapiServer = new Hapi.Server();
-      let lastKnownDeviceStates = new Map();
+      const lastKnownDeviceStates = new Map();
 
       _.forOwn(state.devices, (device, id) => {
         hapiServer.connection({ port: device.port, labels: [id] });
@@ -69,6 +69,7 @@ module.exports.startVirtualDeviceEndpoints = function(state, getDeviceSetupFunct
             return Boom.badRequest();
           }
 
+          // Get state
           if (request.payload.indexOf('</u:GetBinaryState>') > 0) {
             let state = lastKnownDeviceStates.get(device.id) || 0;
             if (_.isFunction(device.getStateHandler)) {

--- a/lib/deviceEndpoints.js
+++ b/lib/deviceEndpoints.js
@@ -85,12 +85,6 @@ module.exports.startVirtualDeviceEndpoints = function(state, getDeviceSetupFunct
             return reply(xmlResponse({ getOrSet: 'get', state }));
           }
 
-          const isSetAction = request.payload.indexOf('</u:SetBinaryState>') > 0;
-          if (!isSetAction) {
-            debug('SetBinaryState Query ignored');
-            return reply({ok: true});
-          }
-
           if (request.payload.indexOf('<BinaryState>1</BinaryState>') > 0) {
             action = 'on';
             lastKnownDeviceStates.set(device.id, 1);

--- a/lib/discoveryService.js
+++ b/lib/discoveryService.js
@@ -20,8 +20,8 @@ LOCATION: http://${state.ipAddress}:${v.port}/${k}/setup.xml\r
 OPT: "http://schemas.upnp.org/upnp/1/0/"; ns=01\r
 01-NLS: ${state.bootId}\r
 SERVER: Unspecified, UPnP/1.0, Unspecified\r
-ST: urn:Belkin:device:**\r
-USN: uuid:Socket-1_0-${k}::urn:Belkin:device:**\r\n\r\n`;
+ST: urn:upnp:rootdevice\r
+USN: uuid:Socket-1_0-${k}::urn:upnp:rootdevice\r\n\r\n`;
 
     debug('>> sending response string: ', responseString);
     responses.push(Buffer.from(responseString));

--- a/lib/xml-response.js
+++ b/lib/xml-response.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function xmlResponse({ getOrSet, state }) {
-  type = getOrSet.toLowerCase() === 'get' ? 'Get' : 'Set';
+  const type = getOrSet.toLowerCase() === 'get' ? 'Get' : 'Set';
   return `<?xml version="1.0" encoding="utf-8"?>
 <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
   <s:Body>

--- a/lib/xml-response.js
+++ b/lib/xml-response.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = function xmlResponse({ getOrSet, state }) {
+  type = getOrSet.toLowerCase() === 'get' ? 'Get' : 'Set';
+  return `<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+  <s:Body>
+    <u:${type}BinaryStateResponse xmlns:u="urn:Belkin:service:basicevent:1">
+      <BinaryState>${state}</BinaryState>
+    </u:${type}BinaryStateResponse>
+  </s:Body>
+</s:Envelope>`;
+}


### PR DESCRIPTION
- Previous actions are stored in a (volatile) map "lastKnownDeviceStates".

- If a "GetBinaryState" request was received, try to get the current device
  state by calling the custom handler function `device.getStateHandler`.

- If no custom handler function was defined or it returns `undefined`, return
  the remembered state for the device using the map `lastKnownDeviceStates`.

- In any doubt, just return "0" (off).
