### PR TITLE
Added device name in callback to allow using one callback for multipl…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ jspm_packages
 .node_repl_history
 
 .idea
+/.vs

--- a/lib/deviceEndpoints.js
+++ b/lib/deviceEndpoints.js
@@ -76,7 +76,7 @@ module.exports.startVirtualDeviceEndpoints = function(state, getDeviceSetupFunct
           debug('!! Action received for device:\n', device, '\naction:\n', action);
 
           if (device.handler) {
-			  device.handler(action, device.name);
+	    device.handler(action, device.name);
           } else {
             debug('Warning, device has no handler:', device);
           }

--- a/lib/deviceEndpoints.js
+++ b/lib/deviceEndpoints.js
@@ -76,7 +76,7 @@ module.exports.startVirtualDeviceEndpoints = function(state, getDeviceSetupFunct
           debug('!! Action received for device:\n', device, '\naction:\n', action);
 
           if (device.handler) {
-            device.handler(action);
+			  device.handler(action, device.name);
           } else {
             debug('Warning, device has no handler:', device);
           }


### PR DESCRIPTION
Added device name in callback to allow using one callback for multiple device callbacks.

I'm making an "Alexa to MQTT" gateway and need to use a single callback function for all device state change notifications. This change is backwards compatible, but also allows this usage scenario.

_(The added.vs in .gitignore could be omitted. It was added since I use visual studio that creates additional files.)_