### PR TITLE
Fix upnp line endings (fix PS4 games)

### DIFF
--- a/lib/discoveryService.js
+++ b/lib/discoveryService.js
@@ -10,17 +10,17 @@ const q = require('q');
 let udpServer;
 
 function getDiscoveryResponses(state) {
-  let responses = [];
+  const responses = [];
   _.forOwn(state.devices, (v, k) => {
-    let responseString = `HTTP/1.1 200 OK
-CACHE-CONTROL: max-age=86400
-DATE: 2016-10-29
-EXT:
-LOCATION: http://${state.ipAddress}:${v.port}/${k}/setup.xml
-OPT: "http://schemas.upnp.org/upnp/1/0/"; ns=01
-01-NLS: ${state.bootId}
-SERVER: Unspecified, UPnP/1.0, Unspecified
-ST: urn:Belkin:device:**
+    const responseString = `HTTP/1.1 200 OK\r
+CACHE-CONTROL: max-age=86400\r
+DATE: 2018-06-13\r
+EXT:\r
+LOCATION: http://${state.ipAddress}:${v.port}/${k}/setup.xml\r
+OPT: "http://schemas.upnp.org/upnp/1/0/"; ns=01\r
+01-NLS: ${state.bootId}\r
+SERVER: Unspecified, UPnP/1.0, Unspecified\r
+ST: urn:Belkin:device:**\r
 USN: uuid:Socket-1_0-${k}::urn:Belkin:device:**\r\n\r\n`;
 
     debug('>> sending response string: ', responseString);
@@ -32,20 +32,20 @@ USN: uuid:Socket-1_0-${k}::urn:Belkin:device:**\r\n\r\n`;
 
 module.exports.getDeviceSetup = function(state, deviceId) {
   state.bootId++;
-  let response = `<?xml version="1.0"?><root>`;
+  let response = `<?xml version="1.0"?><root>\r\n`;
 
   if (!deviceId) {
     debug('rendering all device setup info..');
 
     _.forOwn(state.devices, (v, k) => {
-      response += `<device>
-            <deviceType>urn:Fauxmo:device:controllee:1</deviceType>
-            <friendlyName>${v.name}</friendlyName>
-            <manufacturer>Belkin International Inc.</manufacturer>
-            <modelName>Emulated Socket</modelName>
-            <modelNumber>3.1415</modelNumber>
-            <UDN>uuid:Socket-1_0-${k}</UDN>
-         </device>`;
+      response += `<device>\r
+            <deviceType>urn:Fauxmo:device:controllee:1</deviceType>\r
+            <friendlyName>${v.name}</friendlyName>\r
+            <manufacturer>Belkin International Inc.</manufacturer>\r
+            <modelName>Emulated Socket</modelName>\r
+            <modelNumber>3.1415</modelNumber>\r
+            <UDN>uuid:Socket-1_0-${k}</UDN>\r
+         </device>\r\n`;
     });
   } else {
     debug('rendering device setup for deviceId:', deviceId);
@@ -55,14 +55,14 @@ module.exports.getDeviceSetup = function(state, deviceId) {
       return Boom.badRequest();
     }
 
-    response += `<device>
-            <deviceType>urn:Fauxmo:device:controllee:1</deviceType>
-            <friendlyName>${state.devices[deviceId].name}</friendlyName>
-            <manufacturer>Belkin International Inc.</manufacturer>
-            <modelName>Emulated Socket</modelName>
-            <modelNumber>3.1415</modelNumber>
-            <UDN>uuid:Socket-1_0-${deviceId}</UDN>
-         </device>`;
+    response += `<device>\r
+            <deviceType>urn:Fauxmo:device:controllee:1</deviceType>\r
+            <friendlyName>${state.devices[deviceId].name}</friendlyName>\r
+            <manufacturer>Belkin International Inc.</manufacturer>\r
+            <modelName>Emulated Socket</modelName>\r
+            <modelNumber>3.1415</modelNumber>\r
+            <UDN>uuid:Socket-1_0-${deviceId}</UDN>\r
+         </device>\r\n`;
   }
   response += '</root>';
 

--- a/lib/discoveryService.js
+++ b/lib/discoveryService.js
@@ -32,20 +32,20 @@ USN: uuid:Socket-1_0-${k}::urn:Belkin:device:**\r\n\r\n`;
 
 module.exports.getDeviceSetup = function(state, deviceId) {
   state.bootId++;
-  let response = `<?xml version="1.0"?><root>\r\n`;
+  let response = `<?xml version="1.0"?><root>`;
 
   if (!deviceId) {
     debug('rendering all device setup info..');
 
     _.forOwn(state.devices, (v, k) => {
-      response += `<device>\r
-            <deviceType>urn:Fauxmo:device:controllee:1</deviceType>\r
-            <friendlyName>${v.name}</friendlyName>\r
-            <manufacturer>Belkin International Inc.</manufacturer>\r
-            <modelName>Emulated Socket</modelName>\r
-            <modelNumber>3.1415</modelNumber>\r
-            <UDN>uuid:Socket-1_0-${k}</UDN>\r
-         </device>\r\n`;
+      response += `<device>
+            <deviceType>urn:Fauxmo:device:controllee:1</deviceType>
+            <friendlyName>${v.name}</friendlyName>
+            <manufacturer>Belkin International Inc.</manufacturer>
+            <modelName>Emulated Socket</modelName>
+            <modelNumber>3.1415</modelNumber>
+            <UDN>uuid:Socket-1_0-${k}</UDN>
+         </device>`;
     });
   } else {
     debug('rendering device setup for deviceId:', deviceId);
@@ -55,14 +55,14 @@ module.exports.getDeviceSetup = function(state, deviceId) {
       return Boom.badRequest();
     }
 
-    response += `<device>\r
-            <deviceType>urn:Fauxmo:device:controllee:1</deviceType>\r
-            <friendlyName>${state.devices[deviceId].name}</friendlyName>\r
-            <manufacturer>Belkin International Inc.</manufacturer>\r
-            <modelName>Emulated Socket</modelName>\r
-            <modelNumber>3.1415</modelNumber>\r
-            <UDN>uuid:Socket-1_0-${deviceId}</UDN>\r
-         </device>\r\n`;
+    response += `<device>
+            <deviceType>urn:Fauxmo:device:controllee:1</deviceType>
+            <friendlyName>${state.devices[deviceId].name}</friendlyName>
+            <manufacturer>Belkin International Inc.</manufacturer>
+            <modelName>Emulated Socket</modelName>
+            <modelNumber>3.1415</modelNumber>
+            <UDN>uuid:Socket-1_0-${deviceId}</UDN>
+         </device>`;
   }
   response += '</root>';
 

--- a/test/discoveryService_test.js
+++ b/test/discoveryService_test.js
@@ -5,14 +5,6 @@ const discoveryService = require('../lib/discoveryService');
 const q = require('q');
 
 describe('lib/discoveryService.js', function() {
-  const deviceId = 123;
-  const state = {
-    devices: {
-      123: {
-        name: 'name of 123'
-      }
-    }
-  };
 
   beforeEach(function() {
     return discoveryService.stopDiscoveryServer();
@@ -37,20 +29,6 @@ describe('lib/discoveryService.js', function() {
       .catch((err) => {
         done(err);
       });
-  });
-
-  it('getDeviceSetup should use correct line endings, single device', function() {
-    const result = discoveryService.getDeviceSetup(state, deviceId);
-    const containsCorrectLineEnding1 = result.startsWith('<?xml version="1.0"?><root>\r\n<device>\r\n');
-    const containsCorrectLineEnding2 = result.includes('<friendlyName>name of 123</friendlyName>\r\n');
-    expect(containsCorrectLineEnding1).to.equal(true);
-    expect(containsCorrectLineEnding2).to.equal(true);
-  });
-
-  it('getDeviceSetup should use correct line endings, all devices', function() {
-    const result = discoveryService.getDeviceSetup(state);
-    const containsCorrectLineEnding = result.startsWith('<?xml version="1.0"?><root>\r\n<device>\r\n');
-    expect(containsCorrectLineEnding).to.equal(true);
   });
 
   it('multiple stop calls should be ignored', function(done) {

--- a/test/discoveryService_test.js
+++ b/test/discoveryService_test.js
@@ -5,6 +5,14 @@ const discoveryService = require('../lib/discoveryService');
 const q = require('q');
 
 describe('lib/discoveryService.js', function() {
+  const deviceId = 123;
+  const state = {
+    devices: {
+      123: {
+        name: 'name of 123'
+      }
+    }
+  };
 
   beforeEach(function() {
     return discoveryService.stopDiscoveryServer();
@@ -31,6 +39,20 @@ describe('lib/discoveryService.js', function() {
       });
   });
 
+  it('getDeviceSetup should use correct line endings, single device', function() {
+    const result = discoveryService.getDeviceSetup(state, deviceId);
+    const containsCorrectLineEnding1 = result.startsWith('<?xml version="1.0"?><root>\r\n<device>\r\n');
+    const containsCorrectLineEnding2 = result.includes('<friendlyName>name of 123</friendlyName>\r\n');
+    expect(containsCorrectLineEnding1).to.equal(true);
+    expect(containsCorrectLineEnding2).to.equal(true);
+  });
+
+  it('getDeviceSetup should use correct line endings, all devices', function() {
+    const result = discoveryService.getDeviceSetup(state);
+    const containsCorrectLineEnding = result.startsWith('<?xml version="1.0"?><root>\r\n<device>\r\n');
+    expect(containsCorrectLineEnding).to.equal(true);
+  });
+
   it('multiple stop calls should be ignored', function(done) {
     q.all([discoveryService.stopDiscoveryServer(),discoveryService.stopDiscoveryServer(),discoveryService.stopDiscoveryServer()])
       .then(() => {
@@ -40,5 +62,7 @@ describe('lib/discoveryService.js', function() {
         return discoveryService.stopDiscoveryServer();
       }).then(done);
   });
+
+
 
 });


### PR DESCRIPTION
While the topic sounds very strange, its in fact quite interesting. Kudos to @nklerk for finding this issue!

Long story short, if a fauxmojs service runs, *some* PS4 games (like Diablo III Reaper of Souls or Call of Duty: Black Ops III) won't start (PS4 running on FW 5.55) but fail with a cryptic error.

It looks like the PS4 UPNP service is very crappy and fails. After adding the missing CR chars to the discovery response, those games run fine again.